### PR TITLE
World Pulling Fixes

### DIFF
--- a/KOMODO-IMPRESS/Assets/IMPRESS/Prefab/WorldPulling.prefab
+++ b/KOMODO-IMPRESS/Assets/IMPRESS/Prefab/WorldPulling.prefab
@@ -99,8 +99,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: debdd6d91d87b624d876090dcc21992a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  scaleMin: 0.835
-  scaleMax: 1.94
+  scaleMin: 0.1
+  scaleMax: 10
   debugAxes: {fileID: 7500337663012258881, guid: 2d19101d6d3ac6c438d33c092cc080b1,
     type: 3}
   showDebugAxes: 0

--- a/KOMODO-IMPRESS/Assets/IMPRESS/Prefab/WorldPulling.prefab
+++ b/KOMODO-IMPRESS/Assets/IMPRESS/Prefab/WorldPulling.prefab
@@ -127,7 +127,8 @@ MonoBehaviour:
   - {fileID: 2100000, guid: 02fef1dbd624dcc4d9c9ab88a7e922d4, type: 2}
   - {fileID: 2100000, guid: d7589b41c4f527c44af461d54cf01d52, type: 2}
   - {fileID: 2100000, guid: 093e7be84ebdb7940ba941aee252cbf9, type: 2}
-  - {fileID: 2100000, guid: 093e7be84ebdb7940ba941aee252cbf9, type: 2}
+  - {fileID: 2100000, guid: 1bf2a636382de314d883fcb85d081587, type: 2}
+  - {fileID: 2100000, guid: 381fb7f0084fa1d4982d467aa0d80e0a, type: 2}
 --- !u!120 &4935357643860465841
 LineRenderer:
   m_ObjectHideFlags: 0

--- a/KOMODO-IMPRESS/Assets/IMPRESS/Scene/Main.unity
+++ b/KOMODO-IMPRESS/Assets/IMPRESS/Scene/Main.unity
@@ -3435,6 +3435,11 @@ PrefabInstance:
       objectReference: {fileID: 6308719959967395149}
     - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
         type: 3}
+      propertyPath: showDebugAxes
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
+        type: 3}
       propertyPath: teleportPlayer
       value: 
       objectReference: {fileID: 8474295771467764973}

--- a/KOMODO-IMPRESS/Assets/IMPRESS/Scene/Main.unity
+++ b/KOMODO-IMPRESS/Assets/IMPRESS/Scene/Main.unity
@@ -3435,11 +3435,6 @@ PrefabInstance:
       objectReference: {fileID: 6308719959967395149}
     - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
         type: 3}
-      propertyPath: showDebugAxes
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
-        type: 3}
       propertyPath: teleportPlayer
       value: 
       objectReference: {fileID: 8474295771467764973}
@@ -3453,21 +3448,6 @@ PrefabInstance:
       propertyPath: hands.Array.data[1]
       value: 
       objectReference: {fileID: 8472804883547595920}
-    - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
-        type: 3}
-      propertyPath: materials.Array.size
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
-        type: 3}
-      propertyPath: materials.Array.data[5]
-      value: 
-      objectReference: {fileID: 2100000, guid: 1bf2a636382de314d883fcb85d081587, type: 2}
-    - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
-        type: 3}
-      propertyPath: materials.Array.data[6]
-      value: 
-      objectReference: {fileID: 2100000, guid: 381fb7f0084fa1d4982d467aa0d80e0a, type: 2}
     - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
         type: 3}
       propertyPath: debugAxesMaterials.Array.size

--- a/KOMODO-IMPRESS/Assets/IMPRESS/Scene/Main.unity
+++ b/KOMODO-IMPRESS/Assets/IMPRESS/Scene/Main.unity
@@ -3455,6 +3455,21 @@ PrefabInstance:
       objectReference: {fileID: 8472804883547595920}
     - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
         type: 3}
+      propertyPath: materials.Array.size
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
+        type: 3}
+      propertyPath: materials.Array.data[5]
+      value: 
+      objectReference: {fileID: 2100000, guid: 1bf2a636382de314d883fcb85d081587, type: 2}
+    - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
+        type: 3}
+      propertyPath: materials.Array.data[6]
+      value: 
+      objectReference: {fileID: 2100000, guid: 381fb7f0084fa1d4982d467aa0d80e0a, type: 2}
+    - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
+        type: 3}
       propertyPath: debugAxesMaterials.Array.size
       value: 3
       objectReference: {fileID: 0}

--- a/KOMODO-IMPRESS/Assets/IMPRESS/Scene/Main.unity
+++ b/KOMODO-IMPRESS/Assets/IMPRESS/Scene/Main.unity
@@ -3435,6 +3435,11 @@ PrefabInstance:
       objectReference: {fileID: 6308719959967395149}
     - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
         type: 3}
+      propertyPath: showDebugAxes
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
+        type: 3}
       propertyPath: teleportPlayer
       value: 
       objectReference: {fileID: 8474295771467764973}
@@ -3448,6 +3453,26 @@ PrefabInstance:
       propertyPath: hands.Array.data[1]
       value: 
       objectReference: {fileID: 8472804883547595920}
+    - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
+        type: 3}
+      propertyPath: debugAxesMaterials.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
+        type: 3}
+      propertyPath: debugAxesMaterials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 7e237e86216b037488af65c67187dc08, type: 2}
+    - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
+        type: 3}
+      propertyPath: debugAxesMaterials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: 8e3029c485da38b46b52bcdb96b9de7a, type: 2}
+    - target: {fileID: 4935357643860465840, guid: 85334d0d9069bb546bb3379686af011c,
+        type: 3}
+      propertyPath: debugAxesMaterials.Array.data[2]
+      value: 
+      objectReference: {fileID: 2100000, guid: 02fef1dbd624dcc4d9c9ab88a7e922d4, type: 2}
     - target: {fileID: 4935357643860465854, guid: 85334d0d9069bb546bb3379686af011c,
         type: 3}
       propertyPath: m_Name

--- a/KOMODO-IMPRESS/Assets/IMPRESS/Scene/OutsideTheMilkyWay.unity
+++ b/KOMODO-IMPRESS/Assets/IMPRESS/Scene/OutsideTheMilkyWay.unity
@@ -218,6 +218,196 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1186417695
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1186417699}
+  - component: {fileID: 1186417698}
+  - component: {fileID: 1186417697}
+  - component: {fileID: 1186417696}
+  m_Layer: 0
+  m_Name: Sphere_Test (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!135 &1186417696
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1186417695}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1186417697
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1186417695}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 3ee727b154ed24e44812c316bb01ef90, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1186417698
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1186417695}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1186417699
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1186417695}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.78, y: 1.02, z: 1.03}
+  m_LocalScale: {x: 0.5, y: 0.17, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1275368507
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1275368511}
+  - component: {fileID: 1275368510}
+  - component: {fileID: 1275368509}
+  - component: {fileID: 1275368508}
+  m_Layer: 0
+  m_Name: Sphere_Test (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!135 &1275368508
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275368507}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1275368509
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275368507}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 3ee727b154ed24e44812c316bb01ef90, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1275368510
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275368507}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1275368511
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275368507}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.29, y: 1.08, z: 1.85}
+  m_LocalScale: {x: 1, y: 0.39, z: 1.69}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1531216788
 GameObject:
   m_ObjectHideFlags: 0
@@ -307,7 +497,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1531216788}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.35, y: -0.89, z: -1.89}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/KOMODO-IMPRESS/Assets/IMPRESS/Scripts/WorldPulling.cs
+++ b/KOMODO-IMPRESS/Assets/IMPRESS/Scripts/WorldPulling.cs
@@ -322,8 +322,6 @@ namespace Komodo.IMPRESS
         [ContextMenu("Start World Pulling")]
         public void StartWorldPulling()
         {
-            Debug.Log("started world pulling"); //TODO Remove
-
             SetInitialValues();
 
             animalRuler.gameObject.SetActive(true);
@@ -374,13 +372,6 @@ namespace Komodo.IMPRESS
         public Vector3 ComputePositionDifference (UpdatingValue<Vector3> handsAveragePosition)
         {
             return handsAveragePosition.Initial - handsAveragePosition.Current;
-        }
-
-        // Computes the dif
-
-        public float ComputeScaleRatio (UpdatingValue<float> handDistance, UpdatingValue<float> playerLocalScaleX)
-        {
-            return handDistance.Initial / handDistance.Current * (playerLocalScaleX.Initial * playerLocalScaleX.Current);
         }
 
         public float ComputeDiffRotationY (Quaternion initial, Quaternion current)
@@ -546,11 +537,6 @@ namespace Komodo.IMPRESS
             handsAverageLocalPosition = new UpdatingValue<Vector3>(currentPivotPointInPlayspace.position - playspace.position);
         }
 
-        public void ScalePlayspaceAroundPoint (float scaleRatio, float newScale)
-        {
-           
-        }
-
         public void UpdateLineRenderersScale (float newScale)
         {
             // TODO: update size of drawing strokes here 
@@ -605,10 +591,6 @@ namespace Komodo.IMPRESS
             // Position
 
             handsAverageLocalPosition.Current = currentPivotPointInPlayspace.position - playspace.position;
-
-            Vector3 newPosition = ComputePositionDifference(handsAverageLocalPosition) + initialLeftEyePosition;
-
-            //TODO put back UpdatePlayerPosition(newPosition);
         }
 
         public void OnDestroy ()

--- a/KOMODO-IMPRESS/Assets/IMPRESS/Scripts/WorldPulling.cs
+++ b/KOMODO-IMPRESS/Assets/IMPRESS/Scripts/WorldPulling.cs
@@ -415,8 +415,7 @@ namespace Komodo.IMPRESS
 
             amount *= -1.0f; // Make our own client rotate in the opposite direction that our hands did
 
-            currentPlayspace.RotateAround(
-            copyOfInitialPivotPointPosition, Vector3.up, amount);
+            currentPlayspace.RotateAround(copyOfInitialPivotPointPosition, Vector3.up, amount);
 
             playspace.position = currentPlayspace.position;
 
@@ -486,7 +485,7 @@ namespace Komodo.IMPRESS
         {
             playspace.localScale = new Vector3(newScale, newScale, newScale);
 
-            playspace.position = ((initialPlayspacePosition - initialPivotPointInPlayspace.position) * scaleRatio) + initialPivotPointInPlayspace.position;
+            playspace.position = ((playspace.position - initialPivotPointInPlayspace.position) * scaleRatio) + initialPivotPointInPlayspace.position;
         }
 
         public void UpdateLineRenderersScale (float newScale)
@@ -501,6 +500,27 @@ namespace Komodo.IMPRESS
 
         public void OnUpdate (float realltime)
         {
+            // Scale
+
+            handDistanceInPlayspace.Current = Vector3.Distance(hands[0].transform.position, hands[1].transform.position) / playspace.localScale.x;
+
+            float unclampedScaleRatio = 1.0f / (handDistanceInPlayspace.Current / handDistanceInPlayspace.Initial);
+
+            float clampedNewScale = Mathf.Clamp(unclampedScaleRatio * initialPlayspaceScale, scaleMin, scaleMax);
+
+            if (clampedNewScale > -0.001f && clampedNewScale < 0.001f)
+            {
+                clampedNewScale = 0.0f;
+            }
+
+            float clampedScaleRatio = clampedNewScale / initialPlayspaceScale;
+
+            ScalePlayspaceAroundPoint(clampedScaleRatio, clampedNewScale);
+
+            UpdateLineRenderersScale(clampedNewScale);
+
+            SendAvatarScaleUpdate(clampedNewScale);
+
             // Rotation
 
             UpdateLocalPivotPoint(currentPivotPointInPlayspace, hands[0].transform.position, hands[1].transform.position);
@@ -510,22 +530,6 @@ namespace Komodo.IMPRESS
             UpdateDebugAxes();
 
             RotatePlayspaceAroundPoint(rotateAmount);
-
-            // Scale
-
-            handDistanceInPlayspace.Current = Vector3.Distance(hands[0].transform.position, hands[1].transform.position) / playspace.localScale.x;
-
-            float unclampedScaleRatio = 1.0f / (handDistanceInPlayspace.Current / handDistanceInPlayspace.Initial);
-
-            float clampedNewScale = Mathf.Clamp(unclampedScaleRatio * initialPlayspaceScale, scaleMin, scaleMax);
-
-            float clampedScaleRatio = clampedNewScale / initialPlayspaceScale;
-
-            ScalePlayspaceAroundPoint(clampedScaleRatio, clampedNewScale);
-
-            UpdateLineRenderersScale(clampedNewScale);
-
-            SendAvatarScaleUpdate(clampedNewScale);
 
             // Ruler
 

--- a/KOMODO-IMPRESS/Assets/IMPRESS/Scripts/WorldPulling.cs
+++ b/KOMODO-IMPRESS/Assets/IMPRESS/Scripts/WorldPulling.cs
@@ -560,12 +560,6 @@ namespace Komodo.IMPRESS
         {
             Destroy(initialPlayspace);
         }
-
-        // TODO remove
-        public Vector3 ComputePositionDifference (UpdatingValue<Vector3> handsAveragePosition)
-        {
-            return handsAveragePosition.Initial - handsAveragePosition.Current;
-        }
     }
 }
 

--- a/KOMODO-IMPRESS/Assets/IMPRESS/Scripts/WorldPulling.cs
+++ b/KOMODO-IMPRESS/Assets/IMPRESS/Scripts/WorldPulling.cs
@@ -10,9 +10,9 @@ namespace Komodo.IMPRESS
 {
     public class WorldPulling : MonoBehaviour, IUpdatable
     {
-        public float scaleMin = 0.835f;
+        public float scaleMin = 0.1f;
 
-        public float scaleMax = 1.94f;
+        public float scaleMax = 10.0f;
 
         public GameObject debugAxes;
 
@@ -476,7 +476,22 @@ namespace Komodo.IMPRESS
 
         public float ComputeRulerValue (float playerScale)
         {
-            return (playerScale - 0.9f) / 1.3f;
+            const float rulerMin = 0.0f;
+
+            const float rulerMax = 1.0f;
+
+            if (scaleMax - scaleMin == 0)
+            {
+                Debug.LogWarning("scaleMax - scaleMin was zero. Setting to 0.1m and 10m and proceeding.");
+
+                scaleMin = 0.1f;
+
+                scaleMax = 10f;
+            }
+
+            float percentScale = (playerScale - scaleMin) / (scaleMax - scaleMin);
+
+            return (percentScale * (rulerMax - rulerMin)) + rulerMin;
         }
 
         public void UpdateRulerValue (float newScale)
@@ -501,6 +516,10 @@ namespace Komodo.IMPRESS
             // Scale
 
             handDistanceInPlayspace = new UpdatingValue<float>(Vector3.Distance(hands[0].position, hands[1].position) / playspace.localScale.x);
+
+            float clampedInitialScale = Mathf.Clamp(playspace.localScale.x, scaleMin, scaleMax);
+
+            playspace.localScale = Vector3.one * clampedInitialScale;
 
             initialPlayspaceScale = playspace.localScale.x;
 

--- a/KOMODO-IMPRESS/Assets/IMPRESS/Scripts/WorldPulling.cs
+++ b/KOMODO-IMPRESS/Assets/IMPRESS/Scripts/WorldPulling.cs
@@ -424,25 +424,37 @@ namespace Komodo.IMPRESS
             // Make our own client rotate in the opposite direction that our hands did
             amount *= -1.0f;
 
-            // Update rotation and position -- temporarily store new transform values inside of initialPlayspace itself
+            // Temporarily store initialPlayspace's values
             Vector3 actualInitialPlayspacePosition = initialPlayspace.transform.position;
 
             Quaternion actualInitialPlayspaceRotation = initialPlayspace.transform.rotation;
 
-            // This is because RotateAround does not return a new transform, so we must operate on an existing object
-            // We don't want to rotate the playspace itself because we want to rotate from some constant initial direction
-            // Rather than rotating from the last frame's playspace's orientation
+            // Update rotation and position
+
+            // We must perform this on initialPlayspace
+            // because RotateAround does not return a new 
+            // transform.
+
+            // We don't want to rotate the playspace itself, because
+            // we want to rotate from some constant initial direction.
+            // Rather than rotating from the last frame's playspace's 
+            // orientation.
             initialPlayspace.transform.RotateAround(copyOfInitialPivotPointPosition, Vector3.up, amount);
 
             playspace.rotation = initialPlayspace.transform.rotation;
 
             // Scale around a point: move to new position
-            playspace.position = ((initialPlayspace.transform.position - copyOfInitialPivotPointPosition) * scaleRatio) + copyOfInitialPivotPointPosition;
+            Vector3 scaledAroundPosition = ((initialPlayspace.transform.position - copyOfInitialPivotPointPosition) * scaleRatio) + copyOfInitialPivotPointPosition;
 
             // Scale around a point: update scale
             playspace.localScale = new Vector3(newScale, newScale, newScale);
 
-            // Reset initialPlayspace
+            // Translate
+            Vector3 deltaPosition = Vector3.zero - (currentPivotPointInPlayspace.position - initialPivotPointInPlayspace.position);
+
+            playspace.position = scaledAroundPosition + deltaPosition;
+
+            // Restore initialPlayspace from stored values
             initialPlayspace.transform.position = actualInitialPlayspacePosition;
 
             initialPlayspace.transform.rotation = actualInitialPlayspaceRotation;

--- a/KOMODO-IMPRESS/ProjectSettings/ProjectSettings.asset
+++ b/KOMODO-IMPRESS/ProjectSettings/ProjectSettings.asset
@@ -168,6 +168,7 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
   - {fileID: 11400000, guid: 6145319c34f440441bbabe329561f17c, type: 2}
   - {fileID: 0}
   - {fileID: 2910771567588298596, guid: ac933aa07b1097d47a08984d469dccfc, type: 2}

--- a/KOMODO-IMPRESS/ProjectSettings/ProjectSettings.asset
+++ b/KOMODO-IMPRESS/ProjectSettings/ProjectSettings.asset
@@ -169,6 +169,7 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
   - {fileID: 11400000, guid: 6145319c34f440441bbabe329561f17c, type: 2}
   - {fileID: 0}
   - {fileID: 2910771567588298596, guid: ac933aa07b1097d47a08984d469dccfc, type: 2}
@@ -635,7 +636,7 @@ PlayerSettings:
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}
   suppressCommonWarnings: 1
-  allowUnsafeCode: 0
+  allowUnsafeCode: 1
   useDeterministicCompilation: 1
   useReferenceAssemblies: 1
   enableRoslynAnalyzers: 1

--- a/KOMODO-IMPRESS/ProjectSettings/ProjectSettings.asset
+++ b/KOMODO-IMPRESS/ProjectSettings/ProjectSettings.asset
@@ -170,11 +170,12 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
-  - {fileID: 11400000, guid: 6145319c34f440441bbabe329561f17c, type: 2}
   - {fileID: 0}
-  - {fileID: 2910771567588298596, guid: ac933aa07b1097d47a08984d469dccfc, type: 2}
-  - {fileID: 11400000, guid: a5e5b7605fb48984988490688c2a74e2, type: 2}
-  - {fileID: 2478256764130162806, guid: 552445d583cb06c4eaf9d56596dd45c2, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 11400000, guid: 6145319c34f440441bbabe329561f17c, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/KOMODO-IMPRESS/ProjectSettings/UnityConnectSettings.asset
+++ b/KOMODO-IMPRESS/ProjectSettings/UnityConnectSettings.asset
@@ -9,6 +9,7 @@ UnityConnectSettings:
   m_EventOldUrl: https://api.uca.cloud.unity3d.com/v1/events
   m_EventUrl: https://cdp.cloud.unity3d.com/v1/events
   m_ConfigUrl: https://config.uca.cloud.unity3d.com
+  m_DashboardUrl: https://dashboard.unity3d.com
   m_TestInitMode: 0
   CrashReportingSettings:
     m_EventUrl: https://perf-events.cloud.unity3d.com


### PR DESCRIPTION
# World Pulling Fixes

## Scale, Rotate, Position

You can now grab the world and expect those two points of the world to stay positioned where your hands are. As a result, it does feel more like pulling the world. (Remember, though, you are effectively transforming yourself in the inverse way.)

Additionally, this is fully compatible with the snap turns feature; the bug where snap-turning before world pulling would result in broken rotation is now repaired.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing 
- [ ] Change that requires a documentation update

### How Has This Been Tested?

- [x] Manual Test
- [ ] Unit Test
- [ ] Integration / End-to-End Test

Steps to test: 

1. Use Unity with a Link, Rift, or Rift S.
1. Enter Play mode. 
1. Squeeze both triggers to begin world pulling. 
1. Move your hands further apart or close together to scale.
1. Rotate your hands like spinning a plate by the edges to rotate.
1. Move your hands to move the world.

Expected result: The world appears to move as if you are grabbing it.

## Increased Scale Range, Repaired Ruler

The scale of the player now goes from 0.1m to 10m. This is configurable in the inspector. If the player's starts outside the range specified, it will default to 0.1m min and 10m max. Calculating the texture position on the animal ruler (taken from Google Tilt Brush) has now been refactored for clarity.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing 
- [ ] Change that requires a documentation update

### How Has This Been Tested?

Steps to test: 

1. Enter Play mode. 
2. Perform world pulling scaling.
3. Try to scale yourself large.
4. Try to scale yourself small. 

Expected result: The scale is clamped to a minimum and maximum, and the dinosaur is shown at the largest scale and the squirrel is shown at the smallest scale.

- [x] Manual Test
- [ ] Unit Test
- [ ] Integration / End-to-End Test

## Debug Axes

The position and rotation (and sometimes scale) of both utility objects created by the world pulling code and elements of the XR rig can be observed with the debug axes feature. To use it, access the World Pulling gameObject in the scene, and check the "Show Debug Axes" checkbox.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Testing 
- [ ] Change that requires a documentation update

### How Has This Been Tested?

See above.

Expected result: Some debug axes show the initial positions of the playspace, pivot point local to the playspace, and global pivot point. The remaining debug axes show the current transforms of the playspace, pivot point local to the playspace, and hands. 

- [x] Manual Test
- [ ] Unit Test
- [ ] Integration / End-to-End Test
____

## Test Configuration

No browser yet

Oculus Quest with Link

Unity Editor

Windows 10

# Checklist:

- [ ] ~~My code follows the style guidelines of this project~~
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas that are not self-documenting
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings 
- [x] My changes have no unnecessary logging
- [ ] I have added tests that prove my fix is effective or that my feature works, for sufficiently complex features
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Sensitive info like tokens, secrets, and passwords have been removed before submitting

Modified from this article:
Phillip Johnston, “A GitHub Pull Request Template for Your Projects - Embedded Artistry,” Embedded Artistry, Aug. 04, 2017. https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ (accessed Jul. 22, 2021).
